### PR TITLE
Update for autobase tag 1.0.0-alpha.8

### DIFF
--- a/solutions/07/hypernews.js
+++ b/solutions/07/hypernews.js
@@ -31,19 +31,19 @@ class Hypernews {
 
   async start () {
     const writer = this.store.get({ name: 'writer' })
-    const autobaseIndex = this.store.get({ name: 'index' })
+    const viewOutput = this.store.get({ name: 'view-output' })
 
     await writer.ready()
 
     this.name = args.name || writer.key.slice(0, 8).toString('hex')
-    this.autobase = new Autobase([writer], { indexes: autobaseIndex })
+    this.autobase = new Autobase( { inputs: [writer], localInput: writer , outputs: [viewOutput] })
 
     for (const w of [].concat(args.writers || [])) {
-      await this.autobase.addInput(this.store.get(Buffer.from(w, 'hex')))
+      await this.autobase.addLocalInput(this.store.get(Buffer.from(w, 'hex')))
     }
 
     for (const i of [].concat(args.indexes || [])) {
-      await this.autobase.addDefaultIndex(this.store.get(Buffer.from(i, 'hex')))
+      await this.autobase.addDefaultOutput(this.store.get(Buffer.from(i, 'hex')))
     }
 
     await this.autobase.ready()
@@ -60,7 +60,7 @@ class Hypernews {
     this.info()
 
     const self = this
-    const view = this.autobase.linearize({
+    const view = this.autobase.start({
       unwrap: true,
       async apply (batch) {
         const b = self.bee.batch({ update: false })
@@ -91,7 +91,7 @@ class Hypernews {
       }
     })
 
-    this.bee = new Hyperbee(view, {
+    this.bee = new Hyperbee(this.autobase.view, {
       extension: false,
       keyEncoding: 'utf-8',
       valueEncoding: 'json'
@@ -104,7 +104,7 @@ class Hypernews {
     console.log('hrepl hypernews.js ' +
       '-n ' + this.name + ' ' +
       this.autobase.inputs.map(i => '-w ' + i.key.toString('hex')).join(' ') + ' ' +
-      this.autobase.defaultOutputs.map(i => '-i ' + i.key.toString('hex')).join(' ')
+      this.autobase.outputs.map(i => '-i ' + i.key.toString('hex')).join(' ')
     )
     console.log()
     console.log('To use another storage directory use --storage ./another')

--- a/solutions/07/package.json
+++ b/solutions/07/package.json
@@ -1,0 +1,13 @@
+{
+  "type": "module",
+  "dependencies": {
+    "autobase": "1.0.0-alpha.8",
+    "corestore": "next",
+    "hrepl": "^1.1.3",
+    "hyperbee": "^1.6.3",
+    "hyperswarm": "next",
+    "lexicographic-integer": "^1.1.0",
+    "minimist": "^1.2.5",
+    "random-access-memory": "^3.1.2"
+  }
+}


### PR DESCRIPTION
These are the minimal changes required to make this solution work with autobase release/tag 1.0.0-alpha.8

The package.json file was taken from problems/07/package.json and then hrepl added and autobase changed from latest to 1.0.0-alpha.8

Due to the autobase codebase and API often having breaking changes, it's preferred to point to a specific release, rather than "latest".